### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/nodo_merida/stardust_bridge/bridge.py
+++ b/nodo_merida/stardust_bridge/bridge.py
@@ -21,9 +21,11 @@ async def chat_proxy(request: Request):
             response = await client.post(f"{OLLAMA_HOST}/api/chat", json=data)
             return response.json()
     except httpx.RequestError as e:
-        return JSONResponse(status_code=500, content={"error": f"Error de conexión con Ollama: {str(e)}"})
+        app.logger.exception("Error de conexión con Ollama")
+        return JSONResponse(status_code=500, content={"error": "Error de conexión con Ollama"})
     except Exception as e:
-        return JSONResponse(status_code=500, content={"error": f"Error procesando la respuesta: {str(e)}"})
+        app.logger.exception("Error procesando la respuesta de Ollama")
+        return JSONResponse(status_code=500, content={"error": "Error interno procesando la respuesta"})
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
Potential fix for [https://github.com/bioconexion3i/convocatoriapuentecosmico2027-2079/security/code-scanning/3](https://github.com/bioconexion3i/convocatoriapuentecosmico2027-2079/security/code-scanning/3)

La corrección consiste en **no incluir detalles de excepción en la respuesta HTTP** y, si se necesita diagnóstico, **registrarlos solo del lado servidor**.

Mejor enfoque sin cambiar funcionalidad principal:
- En `nodo_merida/stardust_bridge/bridge.py`, dentro de `chat_proxy`:
  - Cambiar el `except httpx.RequestError as e` para devolver un mensaje genérico (por ejemplo, `"Error de conexión con Ollama"`), sin `str(e)`.
  - Cambiar también el `except Exception as e` de forma equivalente para evitar exposición similar en errores no previstos.
  - Registrar el detalle internamente usando `app.logger.exception(...)` (incluye traceback en logs del servidor).

No se requieren nuevas dependencias. Tampoco es necesario alterar rutas, contratos de éxito, ni estructura general del endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
