### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-adhesiones.yml
+++ b/.github/workflows/auto-adhesiones.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-and-validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bioconexion3i/convocatoriapuentecosmico2027-2079/security/code-scanning/9](https://github.com/bioconexion3i/convocatoriapuentecosmico2027-2079/security/code-scanning/9)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to the minimum required scope.  
Best fix here: at the workflow root (applies to all jobs), set:

- `contents: read`

This preserves current functionality (`actions/checkout` + local JSON validation) while preventing accidental write-capable token usage.

**File to change:** `.github/workflows/auto-adhesiones.yml`  
**Region:** after the `on:` trigger block and before `jobs:`.  
No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
