### PR TITLE
fix(merida): configure MQTT publisher for native broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 nodo_merida/data/
 nodo_merida/logs/
+
+.venv/

--- a/nodo_merida/Dockerfile
+++ b/nodo_merida/Dockerfile
@@ -2,11 +2,9 @@ FROM python:3.9-slim
 
 WORKDIR /app
 
-# Copiar dependencias y scripts
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY scripts/ .
 
-# Ejecutar el integrador galáctico
 CMD ["python", "ritual_3i_mqtt.py"]

--- a/nodo_merida/docker-compose.yml
+++ b/nodo_merida/docker-compose.yml
@@ -1,26 +1,13 @@
-version: '3.8'
-
 services:
-  # El corazón de la comunicación: Broker MQTT
-  mosquitto:
-    image: eclipse-mosquitto:latest
-    container_name: stardust_broker
-    ports:
-      - "1883:1883"
-      - "9001:9001"
-    volumes:
-      - ./mosquitto/config:/mosquitto/config
-      - ./mosquitto/data:/mosquitto/data
-
-  # El cerebro astronómico: Script de Telemetría
   faro_publisher:
     build: .
     container_name: faro_merida_engine
-    depends_on:
-      - mosquitto
     environment:
-      - MQTT_BROKER=mosquitto
+      - MQTT_BROKER=host.docker.internal
+      - MQTT_PORT=1884
       - LATITUD=20.9676
       - LONGITUD=-89.6237
       - NODO_ID=merida-avenida-yucatan
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: always

--- a/nodo_merida/requirements.txt
+++ b/nodo_merida/requirements.txt
@@ -1,0 +1,2 @@
+# Dependencias del Nodo Faro Mérida
+paho-mqtt

--- a/nodo_merida/scripts/ritual_3i_mqtt.py
+++ b/nodo_merida/scripts/ritual_3i_mqtt.py
@@ -8,10 +8,12 @@ Estabilidad: parches E-01, M-01, M-02, E-04 + ajuste paho-mqtt v2
 """
 
 import json
+import os
 import time
 import signal
 import sys
 import random
+from pathlib import Path
 import logging
 from datetime import datetime, timezone
 
@@ -23,10 +25,31 @@ from engine_bioconexion import get_bioconexion_state, get_jdn
 # ============================================================
 # CONFIGURACIÓN
 # ============================================================
-BROKER_HOST = "127.0.0.1"
-BROKER_PORT = 1883
+def _get_mqtt_host(environ=None):
+    env = environ if environ is not None else os.environ
+    return env.get("MQTT_BROKER", "127.0.0.1")
+
+
+def _get_mqtt_port(environ=None):
+    env = environ if environ is not None else os.environ
+    raw_port = env.get("MQTT_PORT", "1883")
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"MQTT_PORT inválido: {raw_port!r}. Debe ser un entero."
+        ) from exc
+    if not 1 <= port <= 65535:
+        raise ValueError(
+            f"MQTT_PORT fuera de rango (1-65535): {port}."
+        )
+    return port
+
+
+BROKER_HOST = _get_mqtt_host()
+BROKER_PORT = _get_mqtt_port()
 CLIENT_ID = f"ritual_3i_{random.randint(1000, 9999)}"
-NAHUALES_JSON = "nahuales.json"
+NAHUALES_JSON = Path(__file__).resolve().parent / "nahuales.json"
 TOPIC_TELEMETRIA = "stardust/merida/telemetria"
 RITMO_SEGUNDOS = 30
 

--- a/nodo_merida/scripts/tests/test_reloj_cosmico.py
+++ b/nodo_merida/scripts/tests/test_reloj_cosmico.py
@@ -1,0 +1,165 @@
+"""
+Pruebas unitarias del reloj cósmico del Nodo Faro Mérida.
+
+Alcance:
+  - FECHA_BASE_MAYA = 2012-12-21 (13.0.0.0.0, 4 Ajaw 3 K'ank'in),
+    conforme a nodo_merida/Readme.md (fuente normativa).
+  - Inicios de ciclo cada 819 días.
+  - Cuadrantes cada 204.75 días con margen de ±0.5 días (±12 h).
+  - es_momento_ritual() en fronteras, vísperas y fechas reales.
+  - Cobertura total de esta versión: 37 casos.
+
+Restricciones respetadas:
+  - La firma de es_momento_ritual() NO se modifica; la fecha se controla
+    sustituyendo `datetime` en el namespace del módulo (monkeypatch).
+  - No se extraen constantes del módulo: las pruebas usan literales.
+  - Sin red, sin MQTT, sin servicios: importar reloj_cosmico no publica nada.
+
+Ejecución:
+    python -m pytest nodo_merida/scripts/tests/test_reloj_cosmico.py -v
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+
+# Permite ejecutar pytest desde cualquier directorio del repositorio
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
+import reloj_cosmico  # noqa: E402
+
+BASE = datetime(2012, 12, 21)  # 13.0.0.0.0 — nodo_merida/Readme.md
+
+
+@pytest.fixture
+def con_fecha(monkeypatch):
+    """Fija datetime.now() visto por reloj_cosmico a una fecha arbitraria.
+
+    Sustituye el nombre `datetime` DENTRO del módulo por una subclase
+    cuyo now() devuelve la fecha indicada. La firma pública de
+    es_momento_ritual() permanece intacta. La resta entre instancias de
+    la subclase y FECHA_BASE_MAYA (creada con el datetime original en el
+    import) es válida por herencia: ambas son datetime.
+    """
+
+    class _RelojFijo(datetime):
+        _fija = None
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls._fija
+
+    def _poner(fecha):
+        _RelojFijo._fija = fecha
+        monkeypatch.setattr(reloj_cosmico, "datetime", _RelojFijo)
+
+    return _poner
+
+
+def _dia(n):
+    """Fecha civil N días después de la fecha base maestra."""
+    return BASE + timedelta(days=n)
+
+
+# ---------------------------------------------------------------------------
+# 1. Fecha base (regresión de la Fase A)
+# ---------------------------------------------------------------------------
+
+def test_fecha_base_maestra_es_2012():
+    assert reloj_cosmico.FECHA_BASE_MAYA == BASE
+
+
+def test_fecha_base_no_es_la_erronea_2020():
+    # Regresión explícita (Fase A): la constante previa e incorrecta
+    # era datetime(2020, 12, 21).
+    assert reloj_cosmico.FECHA_BASE_MAYA.year != 2020
+
+
+# ---------------------------------------------------------------------------
+# 2. Inicios de ciclo (dias_desde_base % 819 == 0)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n", [0, 819, 1638, 2457, 3276, 4095, 4914, 5733])
+def test_inicio_de_ciclo_es_ritual(con_fecha, n):
+    con_fecha(_dia(n))
+    assert reloj_cosmico.es_momento_ritual() is True
+
+
+@pytest.mark.parametrize("n", [818, 1637, 2456, 4913])
+def test_dia_antes_de_inicio_no_dispara(con_fecha, n):
+    con_fecha(_dia(n))
+    assert reloj_cosmico.es_momento_ritual() is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Límites de cuadrantes (fronteras fraccionarias)
+#
+# Tabla de verdad verificada numéricamente (2026-08-23):
+#   k=1 (204.75): dispara SOLO el día 205    -> |205 - 204.75| = 0.25
+#   k=2 (409.50): dispara los días 409 y 410 -> ambos a distancia 0.50
+#   k=3 (614.25): dispara SOLO el día 614    -> |614 - 614.25| = 0.25
+#
+# Nota: aquí se prueba una SELECCIÓN de puntos vecinos alrededor de cada
+# frontera, no el vecindario completo ±1/±2/±3. La asimetría de disparo
+# es estructural: diffs enteros contra fronteras fraccionarias.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n", [205, 409, 410, 614])
+def test_cuadrante_dispara(con_fecha, n):
+    con_fecha(_dia(n))
+    assert reloj_cosmico.es_momento_ritual() is True
+
+
+@pytest.mark.parametrize(
+    "n", [203, 204, 206, 407, 408, 411, 412, 612, 613, 615, 616]
+)
+def test_vecinos_de_cuadrante_no_disparan(con_fecha, n):
+    con_fecha(_dia(n))
+    assert reloj_cosmico.es_momento_ritual() is False
+
+
+# ---------------------------------------------------------------------------
+# 4. es_momento_ritual() en días ordinarios
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n", [79, 100, 300])
+def test_dia_ordinario_no_es_ritual(con_fecha, n):
+    con_fecha(_dia(n))
+    assert reloj_cosmico.es_momento_ritual() is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Fechas reales documentadas (auditadas el 2026-08-23)
+# ---------------------------------------------------------------------------
+
+def test_2026_06_05_es_inicio_de_ciclo_real(con_fecha):
+    con_fecha(datetime(2026, 6, 5))  # día 4914 = 6 × 819
+    assert reloj_cosmico.es_momento_ritual() is True
+
+
+def test_2028_09_01_es_inicio_de_ciclo_real(con_fecha):
+    con_fecha(datetime(2028, 9, 1))  # día 5733 = 7 × 819
+    assert reloj_cosmico.es_momento_ritual() is True
+
+
+def test_2027_07_19_y_20_son_cuadrante_k2_real(con_fecha):
+    con_fecha(datetime(2027, 7, 19))  # día 409 del ciclo vigente
+    assert reloj_cosmico.es_momento_ritual() is True
+    con_fecha(datetime(2027, 7, 20))  # día 410 del ciclo vigente
+    assert reloj_cosmico.es_momento_ritual() is True
+
+
+def test_2027_07_18_y_21_no_son_rituales(con_fecha):
+    con_fecha(datetime(2027, 7, 18))
+    assert reloj_cosmico.es_momento_ritual() is False
+    con_fecha(datetime(2027, 7, 21))
+    assert reloj_cosmico.es_momento_ritual() is False
+
+
+def test_hoy_de_auditoria_2026_08_23_ordinario(con_fecha):
+    con_fecha(datetime(2026, 8, 23))  # día 79 del ciclo vigente
+    assert reloj_cosmico.es_momento_ritual() is False

--- a/nodo_merida/scripts/tests/test_ritual_config.py
+++ b/nodo_merida/scripts/tests/test_ritual_config.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import ritual_3i_mqtt
+
+
+def test_default_mqtt_host():
+    assert ritual_3i_mqtt._get_mqtt_host({}) == "127.0.0.1"
+
+
+def test_env_mqtt_host():
+    assert ritual_3i_mqtt._get_mqtt_host(
+        {"MQTT_BROKER": "mosquitto"}
+    ) == "mosquitto"
+
+
+def test_valid_port():
+    assert ritual_3i_mqtt._get_mqtt_port({"MQTT_PORT": "1883"}) == 1883
+
+
+def test_invalid_port_type():
+    with pytest.raises(ValueError, match="inválido"):
+        ritual_3i_mqtt._get_mqtt_port({"MQTT_PORT": "not_a_number"})
+
+
+def test_invalid_port_range():
+    with pytest.raises(ValueError, match="fuera de rango"):
+        ritual_3i_mqtt._get_mqtt_port({"MQTT_PORT": "70000"})
+
+
+def test_json_path_is_absolute():
+    expected = Path(ritual_3i_mqtt.__file__).resolve().parent / "nahuales.json"
+    assert isinstance(ritual_3i_mqtt.NAHUALES_JSON, Path)
+    assert ritual_3i_mqtt.NAHUALES_JSON == expected
+    assert ritual_3i_mqtt.NAHUALES_JSON.is_absolute()


### PR DESCRIPTION
## Summary

- remove the duplicated Mosquitto service from Nodo Mérida Compose;
- configure the publisher to use the native MQTT broker through host.docker.internal;
- add MQTT configuration validation and explicit Python dependency declaration;
- add tests for host, port, and nahuales.json path resolution.

## Validation

- Docker Compose configuration validated;
- container rebuilt and started successfully;
- native broker connection confirmed on host.docker.internal:1884;
- two telemetry heartbeats observed;
- 20 nahuales loaded;
- telemetry observed on stardust/merida/telemetria.

## Review status

- Ox: APROBADO CON OBSERVACIONES;
- GLM: APROBADO CON OBSERVACIONES, with its paho-mqtt API concern corrected against the actual commit;
- remaining follow-ups: pin paho-mqtt, add integration coverage, improve reconnection handling, and harden anonymous MQTT access with authentication and ACLs.

## Security note

The current native broker listener allows anonymous access and is restricted to the Docker bridge interface. Authentication and ACL hardening should be handled as a follow-up change.