### PR TITLE
refactor(merida): harden MQTT client and pin dependency

### DIFF
--- a/nodo_merida/requirements.txt
+++ b/nodo_merida/requirements.txt
@@ -1,2 +1,2 @@
 # Dependencias del Nodo Faro Mérida
-paho-mqtt
+paho-mqtt==2.1.0

--- a/nodo_merida/scripts/ritual_3i_mqtt.py
+++ b/nodo_merida/scripts/ritual_3i_mqtt.py
@@ -4,22 +4,21 @@
 Ritual 3I - Nodo Faro Mérida
 PUENTE ADAPTADO AL MOTOR REAL (2026-08-01)
 Motor: engine_bioconexion.py (funciones sueltas)
-Estabilidad: parches E-01, M-01, M-02, E-04 + ajuste paho-mqtt v2
+Estabilidad: parches E-01, M-01, M-02, E-04 + paho-mqtt v2
 """
 
 import json
+import logging
 import os
-import time
+import random
 import signal
 import sys
-import random
-from pathlib import Path
-import logging
+import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import paho.mqtt.client as mqtt
 
-# Importar las funciones reales del motor
 from engine_bioconexion import get_bioconexion_state, get_jdn
 
 # ============================================================
@@ -40,9 +39,7 @@ def _get_mqtt_port(environ=None):
             f"MQTT_PORT inválido: {raw_port!r}. Debe ser un entero."
         ) from exc
     if not 1 <= port <= 65535:
-        raise ValueError(
-            f"MQTT_PORT fuera de rango (1-65535): {port}."
-        )
+        raise ValueError(f"MQTT_PORT fuera de rango (1-65535): {port}.")
     return port
 
 
@@ -52,74 +49,115 @@ CLIENT_ID = f"ritual_3i_{random.randint(1000, 9999)}"
 NAHUALES_JSON = Path(__file__).resolve().parent / "nahuales.json"
 TOPIC_TELEMETRIA = "stardust/merida/telemetria"
 RITMO_SEGUNDOS = 30
-
-# Correlación GMT estándar para el calendario Maya (Cuenta Larga)
 MAYA_GMT_CORRELATION = 584283
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S"
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
 
 # ============================================================
-# CARGA DE NAHUALES (Parche E-01)
+# CARGA DE NAHUALES
 # ============================================================
 def cargar_nahuales():
     """Carga el archivo de nahuales. Nunca devuelve None."""
     try:
-        with open(NAHUALES_JSON, 'r', encoding='utf-8') as f:
-            data = json.load(f)
+        with NAHUALES_JSON.open("r", encoding="utf-8") as file_handle:
+            data = json.load(file_handle)
         if isinstance(data, dict) and "nahuales" in data:
             return data["nahuales"]
         logger.warning("El archivo nahuales.json no tiene la estructura esperada.")
-        return []
     except FileNotFoundError:
         logger.warning("Archivo nahuales.json no encontrado. Usando lista vacía.")
-        return []
-    except json.JSONDecodeError as e:
-        logger.error(f"Error decodificando nahuales.json: {e}")
-        return []
-    except Exception as e:
-        logger.error(f"Error inesperado cargando nahuales: {e}")
-        return []
+    except json.JSONDecodeError as exc:
+        logger.error("Error decodificando nahuales.json: %s", exc)
+    except Exception as exc:
+        logger.error("Error inesperado cargando nahuales: %s", exc)
+    return []
+
 
 # ============================================================
-# MANEJO DE SEÑALES (Parches M-01 y Z-01)
+# MANEJO DE SEÑALES
 # ============================================================
 client = None
 
+
 def signal_handler(sig, frame):
     """Maneja SIGINT y SIGTERM para cerrar limpiamente."""
+    del sig, frame
     logger.info("🛑 Ritual detenido por el Guardián.")
     global client
     try:
-        if client and client.is_connected():
+        if client is not None:
             client.loop_stop()
-            client.disconnect()
+            if client.is_connected():
+                client.disconnect()
             logger.info("Cliente MQTT desconectado con honor.")
-    except Exception as e:
-        logger.error(f"Error al desconectar MQTT: {e}")
+    except Exception as exc:
+        logger.error("Error al desconectar MQTT: %s", exc)
     sys.exit(0)
+
 
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
 # ============================================================
-# PUBLICACIÓN MQTT (Parche E-04)
+# PUBLICACIÓN MQTT
 # ============================================================
-def publicar_ritual(client, topic, payload):
+def publicar_ritual(mqtt_client, topic, payload):
     """Publica un mensaje MQTT con manejo de errores."""
     try:
-        result = client.publish(topic, payload, qos=1)
+        result = mqtt_client.publish(topic, payload, qos=1)
         if result.rc == mqtt.MQTT_ERR_SUCCESS:
             return True
-        logger.error(f"Fallo al publicar en {topic}: código {result.rc}")
-        return False
-    except Exception as e:
-        logger.error(f"Excepción publicando en {topic}: {e}")
-        return False
+        logger.error("Fallo al publicar en %s: código %s", topic, result.rc)
+    except Exception as exc:
+        logger.error("Excepción publicando en %s: %s", topic, exc)
+    return False
+
+
+# ============================================================
+# CONEXIÓN Y RECONEXIÓN
+# ============================================================
+def crear_cliente():
+    """Crea el cliente MQTT usando la API v2 de paho-mqtt."""
+    return mqtt.Client(
+        callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+        client_id=CLIENT_ID,
+    )
+
+
+def conectar_con_reintentos(mqtt_client, max_intentos=None):
+    """Conecta al broker con espera progresiva entre intentos."""
+    intento = 0
+    espera = 2
+
+    while max_intentos is None or intento < max_intentos:
+        intento += 1
+        try:
+            mqtt_client.connect(BROKER_HOST, BROKER_PORT, keepalive=60)
+            logger.info("Conectado al broker MQTT en %s:%s", BROKER_HOST, BROKER_PORT)
+            return True
+        except Exception as exc:
+            logger.error(
+                "Error conectando al broker (intento %s): %s", intento, exc
+            )
+            if max_intentos is not None and intento >= max_intentos:
+                return False
+            time.sleep(espera)
+            espera = min(espera * 2, 60)
+    return False
+
+
+def asegurar_conexion(mqtt_client):
+    """Reintenta la conexión si el broker se desconectó."""
+    if mqtt_client.is_connected():
+        return True
+    logger.warning("Broker MQTT desconectado; iniciando reconexión.")
+    return conectar_con_reintentos(mqtt_client)
+
 
 # ============================================================
 # BUCLE PRINCIPAL
@@ -128,68 +166,74 @@ def main_loop():
     global client
 
     logger.info("🌌 Iniciando Nodo Faro Mérida (Motor Real Activado)...")
+    client = crear_cliente()
 
-    # AJUSTE ARQUITECTO: paho-mqtt >= 2.0 requiere CallbackAPIVersion.VERSION1
-    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id=CLIENT_ID)
-    try:
-        client.connect(BROKER_HOST, BROKER_PORT, keepalive=60)
-        client.loop_start()
-        logger.info(f"Conectado al broker MQTT en {BROKER_HOST}:{BROKER_PORT}")
-    except Exception as e:
-        logger.error(f"Error conectando al broker MQTT: {e}")
+    if not conectar_con_reintentos(client):
+        logger.error("No fue posible conectar al broker MQTT.")
         sys.exit(1)
 
-    # Cargar nahuales
+    client.loop_start()
     nahuales = cargar_nahuales()
-    logger.info(f"✅ {len(nahuales)} nahuales cargados. Motor cosmológico activo.")
+    logger.info("✅ %s nahuales cargados. Motor cosmológico activo.", len(nahuales))
 
     try:
         while True:
             try:
-                # 1. Obtener datos cósmicos reales del motor
+                if not asegurar_conexion(client):
+                    time.sleep(10)
+                    continue
+
                 cosmos_data = get_bioconexion_state()
-                
-                # 2. Calcular Nahual del día
                 now = datetime.now(timezone.utc)
                 jdn = get_jdn(now.year, now.month, now.day)
                 maya_day = int(jdn - MAYA_GMT_CORRELATION)
-                
+
                 nahual_del_dia = None
                 if nahuales:
                     nahual_del_dia = nahuales[maya_day % 20]
 
-                # 3. Construir payload completo
                 payload_dict = {
                     "timestamp": now.isoformat(),
                     "id_nodo": "merida-avenida-yucatan-orin",
-                    "latido": random.randint(60, 80), # Simulación de latido vital
+                    "latido": random.randint(60, 80),
                     "engine_bioconexion": cosmos_data,
-                    "nahual_del_dia": nahual_del_dia
+                    "nahual_del_dia": nahual_del_dia,
                 }
+                payload = json.dumps(
+                    payload_dict,
+                    ensure_ascii=False,
+                    default=str,
+                )
 
-                payload = json.dumps(payload_dict, ensure_ascii=False, default=str)
-                
                 if publicar_ritual(client, TOPIC_TELEMETRIA, payload):
+                    nombre_nahual = (
+                        nahual_del_dia.get("nombre_maya")
+                        if nahual_del_dia
+                        else "N/A"
+                    )
                     logger.info(
-                        f"📡 Latido enviado | Venus: {cosmos_data.get('venus_phase')} | "
-                        f"Día Ciclo: {cosmos_data.get('grand_cycle_day')} | "
-                        f"Nahual: {nahual_del_dia.get('nombre_maya') if nahual_del_dia else 'N/A'}"
+                        "📡 Latido enviado | Venus: %s | Día Ciclo: %s | Nahual: %s",
+                        cosmos_data.get("venus_phase"),
+                        cosmos_data.get("grand_cycle_day"),
+                        nombre_nahual,
                     )
 
                 time.sleep(RITMO_SEGUNDOS)
 
-            except Exception as e:
-                logger.error(f"⚠️ Error en ciclo de telemetría: {e}")
+            except Exception as exc:
+                logger.error("⚠️ Error en ciclo de telemetría: %s", exc)
                 time.sleep(10)
 
     except KeyboardInterrupt:
         logger.info("Interrupción manual detectada.")
     finally:
         logger.info("🧹 Limpiando recursos...")
-        if client and client.is_connected():
+        if client is not None:
             client.loop_stop()
-            client.disconnect()
+            if client.is_connected():
+                client.disconnect()
         logger.info("✅ Faro detenido correctamente. Ometeotl.")
+
 
 if __name__ == "__main__":
     main_loop()


### PR DESCRIPTION
## Summary

- pin `paho-mqtt` to `2.1.0`;
- migrate the Nodo Mérida publisher to `CallbackAPIVersion.VERSION2`;
- add bounded exponential backoff for reconnect attempts;
- preserve the existing telemetry topic and payload contract.

## Validation

- 43 tests passed;
- Python compilation passed;
- Docker image built successfully with `--no-cache`;
- container connected to `host.docker.internal:1884`;
- telemetry publication observed;
- broker restart recovery observed;
- SIGTERM/SIGINT shutdown completed cleanly.

## Review status

- GLM: APROBADO;
- Ox: APROBADO CON OBSERVACIONES regarding message delivery during outages, explicit reconnection logging, broker ACLs, and README coverage.

## Follow-ups

- consider a persistent outbox for delivery guarantees during outages;
- improve explicit reconnect event logging;
- configure authentication and ACLs for Mosquitto;
- automate Docker/MQTT integration tests;
- update `nodo_merida/Readme.md` after the final hardening decisions.

This PR does not modify broker credentials or introduce secrets into the repository.